### PR TITLE
Fix commandPermissionLevelSelf not being respected.

### DIFF
--- a/src/main/java/tschipp/fakename/CommandFakeName.java
+++ b/src/main/java/tschipp/fakename/CommandFakeName.java
@@ -39,6 +39,7 @@ public class CommandFakeName
 				
 		LiteralArgumentBuilder<CommandSource> builder = literal("fakename")
 
+				.requires(src -> {boolean b = src.hasPermissionLevel(Config.SERVER.commandPermissionLevelSelf.get()); System.out.println(b); System.out.println(Config.SERVER.commandPermissionLevelSelf.get()); return b;})
 				.then(
 						literal("real")
 						.then(
@@ -77,6 +78,7 @@ public class CommandFakeName
 						)
 						.then(
 								Commands.argument("fakename", StringArgumentType.string())
+								.requires(src -> {boolean b = src.hasPermissionLevel(Config.SERVER.commandPermissionLevelSelf.get()); System.out.println(b); System.out.println(Config.SERVER.commandPermissionLevelSelf.get()); return b;})
 								.executes((cmd) -> {
 									return handleSetname(cmd.getSource(), Collections.singleton(cmd.getSource().asPlayer()), StringArgumentType.getString(cmd, "fakename"));
 								})

--- a/src/main/java/tschipp/fakename/CommandFakeName.java
+++ b/src/main/java/tschipp/fakename/CommandFakeName.java
@@ -39,7 +39,7 @@ public class CommandFakeName
 				
 		LiteralArgumentBuilder<CommandSource> builder = literal("fakename")
 
-				.requires(src -> {boolean b = src.hasPermissionLevel(Config.SERVER.commandPermissionLevelSelf.get()); System.out.println(b); System.out.println(Config.SERVER.commandPermissionLevelSelf.get()); return b;})
+				.requires(src -> src.hasPermissionLevel(Config.SERVER.commandPermissionLevelSelf.get()))
 				.then(
 						literal("real")
 						.then(
@@ -54,7 +54,7 @@ public class CommandFakeName
 						literal("clear")
 						.then(
 								Commands.argument("target", EntityArgument.players())
-								.requires(src -> {boolean b = src.hasPermissionLevel(Config.SERVER.commandPermissionLevelAll.get()); System.out.println(b); System.out.println(Config.SERVER.commandPermissionLevelAll.get()); return b;})
+								.requires(src -> src.hasPermissionLevel(Config.SERVER.commandPermissionLevelAll.get()))
 								.executes((cmd) -> {
 									return handleClear(cmd.getSource(), EntityArgument.getPlayers(cmd, "target"));
 								})
@@ -78,7 +78,7 @@ public class CommandFakeName
 						)
 						.then(
 								Commands.argument("fakename", StringArgumentType.string())
-								.requires(src -> {boolean b = src.hasPermissionLevel(Config.SERVER.commandPermissionLevelSelf.get()); System.out.println(b); System.out.println(Config.SERVER.commandPermissionLevelSelf.get()); return b;})
+								.requires(src -> src.hasPermissionLevel(Config.SERVER.commandPermissionLevelSelf.get()))
 								.executes((cmd) -> {
 									return handleSetname(cmd.getSource(), Collections.singleton(cmd.getSource().asPlayer()), StringArgumentType.getString(cmd, "fakename"));
 								})


### PR DESCRIPTION
In the current version, the `commandPermissionLevelSelf` setting (for executing `/fakename set <newname>` or `/fakename clear <newname>` was not respected at all. The server-side configuration was never used and any player could change their own fakename.

This fixes this by simply adding an additional `requires` call to `CommandFakeName`, analogously to `commandPermissionLevelAll`.